### PR TITLE
Upgrade project and release workflow to Go 1.25.8

### DIFF
--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -46,11 +46,10 @@ jobs:
       actions: read # To read the workflow path.
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0
     with:
-      go-version: 1.25.0
+      go-version: 1.25.8
       config-file: .github/slsa/${{ matrix.os }}-${{ matrix.arch }}.yml
       upload-assets: true
       upload-tag-name: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.event.release.tag_name }}"
       # =============================================================================================================
       #     Optional: For more options, see https://github.com/slsa-framework/slsa-github-generator#golang-projects
       # =============================================================================================================
-

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/priyansh32/local-doc-renderer
 
-go 1.25.0
+go 1.25.8
 
 require github.com/yuin/goldmark v1.7.16
 


### PR DESCRIPTION
## What was wrong
We were pinned to Go `1.25.0` in source and release workflow.
That left us exposed to known stdlib vulnerabilities already patched upstream.

## What I changed
- Updated `go.mod` to `go 1.25.8`.
- Updated SLSA release workflow `go-version` to `1.25.8`.

## Verification
- `go test ./...`
- `go build .`
- `/tmp/gobin/govulncheck ./...` -> `No vulnerabilities found.`

Fixes #10

Moved us to the patched toolchain line and verified the scan comes back clean.

— Arthur
