### PR TITLE
Restrict main document handler to GET/HEAD

### DIFF
--- a/main.go
+++ b/main.go
@@ -366,10 +366,20 @@ func writePlainError(w http.ResponseWriter, status int, message string) {
 	}
 }
 
+func requireMethods(w http.ResponseWriter, r *http.Request, methods ...string) bool {
+	for _, method := range methods {
+		if r.Method == method {
+			return true
+		}
+	}
+
+	w.Header().Set("Allow", strings.Join(methods, ", "))
+	writePlainError(w, http.StatusMethodNotAllowed, "Method not allowed")
+	return false
+}
+
 func mermaidAssetHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		w.Header().Set("Allow", http.MethodGet+", "+http.MethodHead)
-		writePlainError(w, http.StatusMethodNotAllowed, "Method not allowed")
+	if !requireMethods(w, r, http.MethodGet, http.MethodHead) {
 		return
 	}
 
@@ -683,9 +693,7 @@ func activePathFor(fullPath string) string {
 // ---------------------------------------------------------------------------
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		w.Header().Set("Allow", http.MethodGet+", "+http.MethodHead)
-		writePlainError(w, http.StatusMethodNotAllowed, "Method not allowed")
+	if !requireMethods(w, r, http.MethodGet, http.MethodHead) {
 		return
 	}
 
@@ -745,9 +753,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 // ---------------------------------------------------------------------------
 
 func searchHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", http.MethodGet)
-		writePlainError(w, http.StatusMethodNotAllowed, "Method not allowed")
+	if !requireMethods(w, r, http.MethodGet) {
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -683,6 +683,12 @@ func activePathFor(fullPath string) string {
 // ---------------------------------------------------------------------------
 
 func handler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", http.MethodGet+", "+http.MethodHead)
+		writePlainError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+
 	fullPath, err := resolveRequestedFile(r.URL.Path)
 	if err != nil {
 		if errors.Is(err, errOutsideRoot) || errors.Is(err, os.ErrNotExist) {


### PR DESCRIPTION
## What was wrong
The main document handler accepted methods beyond `GET` and `HEAD`.
Other endpoints already enforced method restrictions, so behavior was inconsistent.

## What I changed
- Added an early method guard in `handler`.
- Allowed methods: `GET`, `HEAD`.
- Non-allowed methods now return `405 Method Not Allowed` with `Allow: GET, HEAD`.

## Verification
- `go test ./...`
- `go build .`
- Runtime check:
  - `GET /` -> `200`
  - `HEAD /` -> `200`
  - `POST /` -> `405` + `Allow` header

Fixes #12

Small guardrail, now routes behave consistent.

— Arthur
