### PR TITLE
Ignore local local-doc-renderer binary in git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ go.work
 .gomodcache
 
 .env
+local-doc-renderer


### PR DESCRIPTION
## What was wrong
Local Linux/macOS builds produce a `local-doc-renderer` binary that wasn’t ignored.
It kept showing up in status and could be accidentally staged.

## What I changed
- Added `local-doc-renderer` to `.gitignore`.

## Verification
- `go test ./...`
- Confirmed binary no longer appears as untracked after build.

Fixes #15

Just cleaning the trail so status stays useful.

— Arthur
